### PR TITLE
Fix urls for windows environment.

### DIFF
--- a/core/file-tree/index.js
+++ b/core/file-tree/index.js
@@ -65,7 +65,7 @@ function fileTree(dir) {
         var urlToFile = dir + '/' + targetFile,
             baseName = path.basename(dir);
 
-        urlToFile = path.normalize(urlToFile);
+        urlToFile = path.normalize(urlToFile).replace(/\\/g, '/');
         var urlFromHostRoot = urlToFile.replace('../','/');
 
         outputJSON[baseName] = outputJSON[baseName];


### PR DESCRIPTION
Because of windows backslashes urls were not generated properly. Simple replacement fixed the issue.
