### PR TITLE
ejs: include fixed

### DIFF
--- a/core/middleware/wrap.js
+++ b/core/middleware/wrap.js
@@ -9,22 +9,22 @@ var userTemplatesDir = global.app.get('user') + "/core/views/";
 var coreTemplatesDir = pathToApp + "/core/views/";
 
 /**
- * Get template filename: default or user-defined if it exists.
+ * Get full path to template: default or user-defined if it exists.
  *
  *
  * @param {string} name - Template name
  * @returns {string}
  * */
-function getTemplateFilename(name) {
-    var filename;
+function getTemplateFullPath (name) {
+    var pathToTemplate;
 
     if (fs.existsSync(userTemplatesDir + name)) {
-        filename = userTemplatesDir + name;
+        pathToTemplate = userTemplatesDir + name;
     } else {
-        filename = coreTemplatesDir + name;
+        pathToTemplate = coreTemplatesDir + name;
     }
 
-    return filename;
+    return pathToTemplate;
 }
 
 /**
@@ -47,15 +47,15 @@ exports.process = function (req, res, next) {
         var headerFooterHTML = getHeaderAndFooter();
 
         // choose the proper template, depending on page type
-        var template, templateFilename;
+        var template, templatePath;
         if (info.template) {
-            templateFilename = getTemplateFilename(info.template + '.ejs');
+            templatePath = getTemplateFullPath(info.template + ".ejs");
         } else if (info.role === 'navigation') {
-            templateFilename = getTemplateFilename("navigation.ejs");
+            templatePath = getTemplateFullPath("navigation.ejs");
         } else {
-            templateFilename = getTemplateFilename("spec.ejs");
+            templatePath = getTemplateFullPath("spec.ejs");
         }
-        template = fs.readFileSync(templateFilename, "utf-8");
+        template = fs.readFileSync(templatePath, "utf-8");
 
         // if the following fields are not set, set them to defaults
         info.title = info.title ? info.title : "New spec";
@@ -68,7 +68,7 @@ exports.process = function (req, res, next) {
             header  : headerFooterHTML.header,
             footer  : headerFooterHTML.footer,
             info    : info,
-            filename: templateFilename
+            filename: templatePath
         };
 
         // render page and send it as response


### PR DESCRIPTION
ejs can include external file content into template, but not working in current sourcejs/v.0.4.0
PR changes:
- `filename` parameter added to `options` (https://github.com/visionmedia/ejs/blob/master/ejs.js#L214)
- `getTemplate` logic refactored
