### PR TITLE
Fix JSDom template double <body> tag

### DIFF
--- a/core/middleware/wrap.js
+++ b/core/middleware/wrap.js
@@ -87,6 +87,9 @@ exports.process = function (req, res, next) {
                         specData.removeChild(headHook);
                     }
 
+                    // make sure the body is not passed again once the head is removed
+                    specData = specData.getElementsByTagName('body')[0];
+
                     // final data object for the template
                     var templateJSON = {
                         content: specData.innerHTML,


### PR DESCRIPTION
As explained in #134 this will fix the double `<body>` until JSDom is removed.