### PR TITLE
Ndelangen/tags in autocomplete value

### DIFF
--- a/assets/js/modules/search.js
+++ b/assets/js/modules/search.js
@@ -72,18 +72,18 @@ Search.prototype.prepareAutoCompleteData = function() {
             // Skip hidden specs
             if (targetPage.tag && targetPage.tag.indexOf('hidden') > -1) continue;
 
-            var keywords = targetPage.keywords;
-            var keywordsPageName = pagesData[page] && pagesData[page]['name']
+            var tag = targetPage.tag;
+            var pageName = pagesData[page] && pagesData[page]['name']
                 ? pagesData[page]['name']
                 : ""; //get cat name
-            var prepareKeywords = '';
+            var tags = '';
             var autocompleteValue = targetPage.title;
 
-            if (keywords && keywords !== '') {
-                prepareKeywords += ', ' + keywords;
+            if (tag && tag.length) {
+                tags += ', ' + tag.join(' ');
             }
 
-            autocompleteValue += ' (' + keywordsPageName + prepareKeywords + ')';
+            autocompleteValue += ' (' + pageName + tags + ')';
             this.data[this.data.length] = new AutocomleteDataItem(autocompleteValue, targetPage.url);
         }
     }

--- a/assets/js/modules/search.js
+++ b/assets/js/modules/search.js
@@ -80,7 +80,7 @@ Search.prototype.prepareAutoCompleteData = function() {
             var autocompleteValue = targetPage.title;
 
             if (tag && tag.length) {
-                tags += ', ' + tag.join(' ');
+                tags += ', ' + tag.join(', ');
             }
 
             autocompleteValue += ' (' + pageName + tags + ')';

--- a/docs/api/load-events/info.json
+++ b/docs/api/load-events/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "events, spec loaded",
+    "tag": ["events", "spec", "loaded"],
     "title": "Spec Load Event",
     "template": "doc"
 }

--- a/docs/api/plugins/info.json
+++ b/docs/api/plugins/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "plugins, middlewares",
+    "tag": ["plugins", "middlewares"],
     "title": "Writing SourceJS Plugins and Middlewares",
     "template": "doc"
 }

--- a/docs/api/rest-api/info.json
+++ b/docs/api/rest-api/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "api, rest",
+    "tag": ["api", "rest"],
     "title": "REST API",
     "template": "doc"
 }

--- a/docs/auth/info.json
+++ b/docs/auth/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "auth, github",
+    "tag": ["auth", "github"],
     "title": "Using Github Auth",
     "template": "doc"
 }

--- a/docs/configuration/info.json
+++ b/docs/configuration/info.json
@@ -1,5 +1,5 @@
 {
     "title": "Engine Configuration",
-    "keywords": "options, options.js, sourcejs-options, context",
+    "tag": ["options", "options.js", "sourcejs-options", "context"],
     "template": "doc"
 }

--- a/docs/info-json/info.json
+++ b/docs/info-json/info.json
@@ -1,5 +1,5 @@
 {
     "title": "Info.json - Spec Description",
-    "keywords": "spec meta, template, specFile",
+    "tag": ["tag", "title", "thumbnailPath", "specFile", "template", "role", "info", "spec meta"],
     "template": "doc"
 }

--- a/docs/info-json/readme.md
+++ b/docs/info-json/readme.md
@@ -8,7 +8,7 @@ List of used options in `info.json`:
 {
     "title": "Info.json - Spec Description",
     "author": "Robert Haritonov",
-    "tag": ["tags, for, search"],
+    "tag": ["tags", "for", "search"],
     "info": "Spec description.",
     "role": "navigation",
     "template": ["custom" | "$(context)/template.ejs"],

--- a/docs/spec-helpers/info.json
+++ b/docs/spec-helpers/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "ejs, include",
+    "tag": ["ejs", "include"],
     "title": "Spec Rendering Helpers",
     "template": "doc"
 }

--- a/docs/spec/info.json
+++ b/docs/spec/info.json
@@ -1,5 +1,5 @@
 {
-    "keywords": "create spec, spec markup",
+    "tag": ["create spec", "spec markup"],
     "template": "doc",
     "title": "Spec Page Documentation"
 }


### PR DESCRIPTION
* CHANGED the `keyword` property in info.json files to `tag`.
* CORRECTED documentation regarding this property.
* IMPROVED tag info for `docs/info-json/info.json`. to make it easier to find, when searching docs for a what a property within an `info.json` does.