### PR TITLE
Allow code definition blocks to be ignored

### DIFF
--- a/assets/js/modules/codeSource.js
+++ b/assets/js/modules/codeSource.js
@@ -170,7 +170,9 @@ define([
             };
 
             var afterActivation = function() {
-                var sources = $('.' + SourceCode);
+                var sources = $('.' + SourceCode).filter(function() {
+                    return !$(this).next().hasClass('source_ignore');
+                });
                 sources.addClass(SourceCodeShow);
 
                 //Scroll to section
@@ -192,7 +194,9 @@ define([
                 if (!prepared) {
                     fillCodeContainers();
                     prepareCodeBlocks();
-                    $('pre').removeAttr('style');
+                    $('pre').filter(function() {
+                        return !$(this).closest('.source_source-code').next().hasClass('source_ignore');
+                    }).removeAttr('style');
                     prepared = true;
                 }
                 afterActivation();


### PR DESCRIPTION
I have a use case where I'm showcasing expected styles of rendered, JavaScript generated, markup — for reasons, we don't want to actually include our JS to generate this markup.

Because this generated markup is often complex and not relevant for our needs; I'd like to be able to suppress the 'Show source code' functionality for specific code blocks.

Here I've achieved this by checking for the `.source_ignore` class.
```
<div class="source_ignore source_example">...</div>
```